### PR TITLE
Url Dispatch Link is Broken

### DIFF
--- a/content/docs/application.md
+++ b/content/docs/application.md
@@ -29,7 +29,7 @@ In this example, an application with the `/app` prefix and a `index.html` resour
 are created. This resource is available through the `/app/index.html` url.
 
 > For more information, check the
-> [URL Dispatch](./docs/url-dispatch/index.html#using-an-application-prefix-to-compose-applications) section.
+> [URL Dispatch](/docs/url-dispatch/index.html#using-an-application-prefix-to-compose-applications) section.
 
 Multiple applications can be served with one server:
 


### PR DESCRIPTION
Writing an Application document (application.md) refer Url Dispatch document but path is not valid. I fixed with correct value.

Current link navigate to (404)
"./docs/url-dispatch/index.html#using-an-application-prefix-to-compose-applications"

I changed it to
"/docs/url-dispatch/index.html#using-an-application-prefix-to-compose-applications"
<img width="974" alt="screen shot 2018-09-23 at 22 37 59" src="https://user-images.githubusercontent.com/1244956/45932215-cca74200-bf81-11e8-8eeb-2a9218104f02.png">

<img width="903" alt="screen shot 2018-09-23 at 22 38 11" src="https://user-images.githubusercontent.com/1244956/45932219-db8df480-bf81-11e8-8535-2ae83278dd35.png">


<img width="1086" alt="screen shot 2018-09-23 at 22 43 44" src="https://user-images.githubusercontent.com/1244956/45932248-39224100-bf82-11e8-8f91-3869f48532f9.png">

